### PR TITLE
fix metadata and filename

### DIFF
--- a/content/white-paper/cloud-files-aid-resume-reinvention.html
+++ b/content/white-paper/cloud-files-aid-resume-reinvention.html
@@ -1,6 +1,6 @@
 ---
 node_id: 3347
-title: Cloud Files Aid R&eacute;sum&eacute; Reinvention
+title: 'Cloud Files Aid R&eacute;sum&eacute; Reinvention'
 type: case_study
 created_date: '2013-03-15'
 created_by: Rackspace Support


### PR DESCRIPTION
Noticed that one of the files had some incorrect metadata and the filename `.html` had a typo so it wasn't displaying properly.